### PR TITLE
Add missing line to stop update_opinion after it is started

### DIFF
--- a/script/stop_internal.sh
+++ b/script/stop_internal.sh
@@ -3,6 +3,7 @@ echo "Stopping backend elements in screen sessions"
 screen -S backend-db-workers -p 0 -X stuff ^C
 screen -S backend-aggregator -p 0 -X stuff ^C
 screen -S backend-scraper -p 0 -X stuff ^C
+screen -S backend-update-opinion -p 0 -X stuff ^C
 screen -S backend-scheduler -p 0 -X stuff ^C
 screen -S backend-art-getter -p 0 -X stuff ^C
 echo "Stopping frontend elements in screen sessions"


### PR DESCRIPTION
This was previously merged and then reverted because I forgot to add it to `stop_internals`, and nobody noticed at the time ;_;

Connects to #122
