### PR TITLE
Add old data back into populating script

### DIFF
--- a/script/mongodb/populate_sample_data.js
+++ b/script/mongodb/populate_sample_data.js
@@ -77,7 +77,7 @@ db.user.insert([
 	email: "ross@feedlark.com",
 	hashed_password: "IjZAgcfl7p92ldGxad68LJZdL17lhWy",
 	password_salt: "N9qo8uLOickgx2ZMRZoMye",
-	subscribed_feeds: ["https://news.ycombinator.com/rss", "http://spritesmods.com/rss.php"]
+	subscribed_feeds: ["https://news.ycombinator.com/rss", "http://spritesmods.com/rss.php", "http://dave.cheney.net/feed"]
 },
 {
 	username: "theotherguys",


### PR DESCRIPTION
Connects to #203 

This just reverts a previous change that removed some data from the script to populate the database, and caused tests to fail, obscuring results from new tests.
