### PR TITLE
Add current date to feed if no date scraped

### DIFF
--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -143,7 +143,11 @@ def update_database(doc, updated_item_list):
     """Updates the database, given a doc and updated_item_list"""
     bson_data = None
     try:
-        bson_data = bsonify_update_data(doc['_id'], doc['url'], updated_item_list)
+        bson_data = bsonify_update_data(
+            doc['_id'],
+            doc['url'],
+            updated_item_list
+            )
     except Exception as e:
         log(2, str(e))
         return str(bson.BSON.encode({
@@ -154,7 +158,11 @@ def update_database(doc, updated_item_list):
     log(0, "Updating feed database")
     update_response = None
     try:
-        update_response = gm_client.submit_job('db-update', str(bson_data), background=True)
+        update_response = gm_client.submit_job(
+            'db-update',
+            str(bson_data),
+            background=True
+            )
     except Exception as e:
         log(2, str(e))
         return str(bson.BSON.encode({

--- a/scraper/testing.py
+++ b/scraper/testing.py
@@ -4,20 +4,21 @@ import scraper as scr
 import gearman
 import bson
 
+
 class TestScraping(unittest.TestCase):
 
     def test_get_feed_data(self):
-        #The url is to a static RSS feed stolen from Hacker News
+        # The url is to a static RSS feed stolen from Hacker News
         test_feed = scr.get_feed_data('http://u.m1cr0man.com/l/feed.xml')
 
         title = 'Why it is NOT WISE to discuss personal information in front of smart TVs'
-        self.assertEqual(test_feed[0]['name'],title)
+        self.assertEqual(test_feed[0]['name'], title)
 
         link = 'http://www.hackernews.org/2016/02/14/why-it-is-not-wise-to-discuss-personal-information-in-front-of-smart-tvs/'
-        self.assertEqual(test_feed[0]['link'],link)
+        self.assertEqual(test_feed[0]['link'], link)
 
-        pub_date = datetime(2016,2,14,21,10,2)
-        self.assertEqual(test_feed[0]['pub_date'],pub_date)
+        pub_date = datetime(2016, 2, 14, 21, 10, 2)
+        self.assertEqual(test_feed[0]['pub_date'], pub_date)
 
         with self.assertRaises(TypeError):
             scr.get_feed_data(666)


### PR DESCRIPTION
Connects to #227 

This takes the date of scraping and sets it as the date. Since items are only scraped once and the scraper is run often, after the feed has been in the database long enough the dates will be accurate.
