### PR TITLE
Fix null regex return on root URLs

### DIFF
--- a/server/views/stream_index.ejs
+++ b/server/views/stream_index.ejs
@@ -59,7 +59,7 @@
             date = date.toLocaleDateString();
             var url = feeds[i].feed.match(/https?:\/\/[^\/]+/g)[0];
             var source_name_re = /https?:\/\/([^\/]+)/g;
-            var link_name_re = /(https?:\/\/[^\/]+\/)/g;
+            var link_name_re = /(https?:\/\/[^\/]+)/g;
             var source_name = source_name_re.exec(feeds[i].feed)[1];
             var link_name = link_name_re.exec(feeds[i].link)[1];
         %>


### PR DESCRIPTION
Connects to #225 

Simple little regex change. Tested in `http://regexr.com` and it should be fine in the code too.
