### PR TITLE
Add check for empty feed list in aggregator

### DIFF
--- a/aggregator/aggregator.py
+++ b/aggregator/aggregator.py
@@ -130,7 +130,7 @@ class Aggregator:
                             'pub_date': item['pub_date'],
                         })
 
-            if user_g2g['feeds'] == []:
+            if 'feeds' not in user_g2g or user_g2g['feeds'] == []:
                 log('No feed items for user', level=1)
                 log('Completed')
                 continue


### PR DESCRIPTION
Connects to #232 

This was occurring because the dates section was catching a specific kind of error, this has been generalized and a check has been added for the special case causing the error.
